### PR TITLE
Fix table rendering in README with blank line for separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Backlog Status
 
-**Latest Run:** 2021-09-01 07:21:10 GMT
+**Latest Run:** 2021-09-01 07:51:04 GMT
 *(Please refresh to see latest results)*
 Backlog Query | Number of Issues | Limits | Status
 --- | --- | --- | ---

--- a/backlog_checker.py
+++ b/backlog_checker.py
@@ -23,7 +23,7 @@ def initialize_md():
     with open("index.md", "a") as md:
         md.write("# Backlog Status\n\n")
         md.write("**Latest Run:** " + datetime.now().strftime("%Y-%m-%d %H:%M:%S") + " GMT\n")
-        md.write("*(Please refresh to see latest results)*\n")
+        md.write("*(Please refresh to see latest results)*\n\n")
         md.write("Backlog Query | Number of Issues | Limits | Status\n--- | --- | --- | ---\n")
 
 


### PR DESCRIPTION
It seems depending on the markdown renderer the table starting with
"Backlog Query" is only properly rendered as a table when the previous
text is separated from the table with a blank line.