### PR TITLE
Try to prevent automatic updates to README in pull requests

### DIFF
--- a/.github/workflows/backlog_checker.yml
+++ b/.github/workflows/backlog_checker.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   check_suse_qa_tools_backlog_limits:
+    if: ${{ github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo content

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Backlog Status
 
-**Latest Run:** 2021-11-12 13:01:51 GMT
+**Latest Run:** 2021-11-13 11:53:41 GMT
 *(Please refresh to see latest results)*
 
 Backlog Query | Number of Issues | Limits | Status
 --- | --- | --- | ---
-| [Overall Backlog](https://progress.opensuse.org/issues?query_id=230) | 79 | <100 | &#x1F49A;
-| [Workable Backlog](https://progress.opensuse.org/issues?query_id=478) | 16 | >10, <40 | &#x1F49A;
-| [Exceeding Due Date](https://progress.opensuse.org/issues?query_id=514) | 5 | <1 | &#x1F534;
+| [Overall Backlog](https://progress.opensuse.org/issues?query_id=230) | 74 | <100 | &#x1F49A;
+| [Workable Backlog](https://progress.opensuse.org/issues?query_id=478) | 12 | >10, <40 | &#x1F49A;
+| [Exceeding Due Date](https://progress.opensuse.org/issues?query_id=514) | 4 | <1 | &#x1F534;
 | [Untriaged Tools Tagged](https://progress.opensuse.org/issues?query_id=481) | 0 | <1 | &#x1F49A;
-| [Untriaged QA](https://progress.opensuse.org/projects/qa/issues?query_id=576) | 0 | <1 | &#x1F49A;
+| [Untriaged QA](https://progress.opensuse.org/projects/qa/issues?query_id=576) | 1 | <1 | &#x1F534;


### PR DESCRIPTION
Created in parallel with https://github.com/os-autoinst/qa-tools-backlog-assistant/pull/12 to crosscheck if the cron schedule triggeres based on branch name or can be controlled per repo