### PR TITLE
Reference current gh-pages in README instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,3 @@
 # Backlog Status
 
-**Latest Run:** 2021-11-25 12:38:48 GMT
-*(Please refresh to see latest results)*
-
-Backlog Query | Number of Issues | Limits | Status
---- | --- | --- | ---
-| [Overall Backlog](https://progress.opensuse.org/issues?query_id=230) | 81 | <100 | &#x1F49A;
-| [Workable Backlog](https://progress.opensuse.org/issues?query_id=478) | 23 | >10, <40 | &#x1F49A;
-| [Exceeding Due Date](https://progress.opensuse.org/issues?query_id=514) | 0 | <1 | &#x1F49A;
-| [Untriaged Tools Tagged](https://progress.opensuse.org/issues?query_id=481) | 0 | <1 | &#x1F49A;
-| [Untriaged QA](https://progress.opensuse.org/projects/qa/issues?query_id=576) | 0 | <1 | &#x1F49A;
+See https://os-autoinst.github.io/qa-tools-backlog-assistant/


### PR DESCRIPTION
After https://github.com/os-autoinst/qa-tools-backlog-assistant/pull/15 merged let's see if this PR still receives forced updates in the README. If not and gh-pages was correctly generated we can reference the content in the README as URL