### PR TITLE
Use sys.exit() over exit()

### DIFF
--- a/backlog_checker.py
+++ b/backlog_checker.py
@@ -133,7 +133,7 @@ def check_query(name):
         res = check_zero(conf)
     if res[0] is False:
         results_to_md(conf, res[1], result_icons["fail"])
-        exit(1)
+        sys.exit(1)
     results_to_md(conf, res[1], result_icons["pass"])
 
 


### PR DESCRIPTION
Use sys.exit() over exit() as exit() is to be used in the "interactive interpreter shell and should not be used in programs."

Source: https://docs.python.org/3/library/constants.html#constants-added-by-the-site-module