### PR TITLE
Add Closed within last 60 days to get cycle time

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -39,3 +39,7 @@ queries:
     query: query_id=520
     max: 30
     min: 1
+  - title: Closed yesterday
+    query: query_id=773
+    max: 0
+    min: 1


### PR DESCRIPTION
A query for closed tickets is needed to compute the cycle time.

See: https://progress.opensuse.org/issues/121582