### PR TITLE
Revert "Add Closed within last 60 days to get cycle time"

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -39,7 +39,3 @@ queries:
     query: query_id=520
     max: 30
     min: 1
-  - title: Closed yesterday
-    query: query_id=773
-    max: 0
-    min: 1


### PR DESCRIPTION
After making the query public https://github.com/os-autoinst/qa-tools-backlog-assistant/actions/runs/4408479813/jobs/7723734130 passed again means https://os-autoinst.github.io/qa-tools-backlog-assistant/ is now updated. However there is a big fat red icon on that page that shouldn't be there. Hence I am proposing to revert for now.

Reverts os-autoinst/qa-tools-backlog-assistant#33