### PR TITLE
Make CI run on push action for master branch

### DIFF
--- a/.github/workflows/backlog_checker.yml
+++ b/.github/workflows/backlog_checker.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: '*/10 * * * *'
   push:
-    branches: ['main']
+    branches: ['master']
   workflow_dispatch:
 permissions:
   contents: write


### PR DESCRIPTION
As for now the CI would search to match main branch but repo has no such branch.