### PR TITLE
Prevent confusion about "Workable Backlog"

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -9,7 +9,7 @@ queries:
   - title: Next
     query: query_id=794
     max: 64
-  - title: Workable Backlog
+  - title: Only workable from backlog
     query: query_id=478
     max: 39
     min: 11


### PR DESCRIPTION
The query 478 is not *the* "workable backlog" but only a filtered view
showing only the workable tickets from the backlog.