### PR TITLE
Add links to both dev+infra backlogs in detail

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -3,9 +3,15 @@ web: https://progress.opensuse.org/issues
 team: QE Tools
 url: https://progress.opensuse.org/projects/qa/wiki/Tools
 queries:
-  - title: Overall Backlog
+  - title: Combined Backlog (dev+infra)
     query: query_id=230
     max: 64
+  - title: Dev Backlog
+    query: query_id=754
+    max: 50
+  - title: Infra Backlog
+    query: query_id=757
+    max: 50
   - title: Next
     query: query_id=794
     max: 64

--- a/queries.yaml
+++ b/queries.yaml
@@ -9,7 +9,7 @@ queries:
   - title: Next
     query: query_id=794
     max: 64
-  - title: Workable Backlog
+  - title: Only workable from backlog
     query: query_id=478
     max: 39
     min: 11


### PR DESCRIPTION
With two teams "dev" and "infra" we should also split backlogs as
referenced on team pages and backlog status view.

Related progress issue: https://progress.opensuse.org/issues/179963