### PR TITLE
chore(ci): bump checkout to v6

### DIFF
--- a/.github/workflows/backlog_checker.yml
+++ b/.github/workflows/backlog_checker.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.ref == 'refs/heads/master' && github.repository_owner == 'os-autoinst' || github.ref == 'refs/heads/testworkflow'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: openSUSE/backlogger@main


### PR DESCRIPTION
This also fixes a warning about outdated nodejs